### PR TITLE
Make allowTransform===false use clientX instead of pageX to calculate position of element

### DIFF
--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -206,11 +206,13 @@ angular.module("ngDraggable", [])
                     if(allowTransform)
                         moveElement(_tx, _ty);
                     else{
+						//Note: does not take into account _centerAnchor
+						//Click offset in element coordinates
 						var ty = _mry - _dragOffset.top;
 						var tx = _mrx - _dragOffset.left;
-                        var trueMoveX = ngDraggable.inputEvent(evt).clientX - tx;
-						var trueMoveY = ngDraggable.inputEvent(evt).clientY - ty;
-						moveElement(trueMoveX, trueMoveY);
+						var newX = ngDraggable.inputEvent(evt).clientX - tx;
+						var newY = ngDraggable.inputEvent(evt).clientY - ty;
+						moveElement(newX, newY);
                     }
 
                     $rootScope.$broadcast('draggable:move', { x: _mx, y: _my, tx: _tx, ty: _ty, event: evt, element: element, data: _data, uid: _myid, dragOffset: _dragOffset });

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -203,7 +203,15 @@ angular.module("ngDraggable", [])
                         _ty = _my - _mry - _dragOffset.top;
                     }
 
-                    moveElement(_tx, _ty);
+                    if(allowTransform)
+                        moveElement(_tx, _ty);
+                    else{
+						var ty = _mry - _dragOffset.top;
+						var tx = _mrx - _dragOffset.left;
+                        var trueMoveX = ngDraggable.inputEvent(evt).clientX - tx;
+						var trueMoveY = ngDraggable.inputEvent(evt).clientY - ty;
+						moveElement(trueMoveX, trueMoveY);
+                    }
 
                     $rootScope.$broadcast('draggable:move', { x: _mx, y: _my, tx: _tx, ty: _ty, event: evt, element: element, data: _data, uid: _myid, dragOffset: _dragOffset });
                 };
@@ -254,7 +262,7 @@ angular.module("ngDraggable", [])
                             '-ms-transform': 'matrix(1, 0, 0, 1, ' + x + ', ' + y + ')'
                         });
                     }else{
-                        element.css({'left':x+'px','top':y+'px', 'position':'fixed'});
+                        element.css({'left': x+'px','top': y+'px', 'position': 'fixed', 'z-index': 99999});
                     }
                 };
                 initialize();

--- a/ngDraggable.js
+++ b/ngDraggable.js
@@ -206,13 +206,13 @@ angular.module("ngDraggable", [])
                     if(allowTransform)
                         moveElement(_tx, _ty);
                     else{
-						//Note: does not take into account _centerAnchor
-						//Click offset in element coordinates
-						var ty = _mry - _dragOffset.top;
-						var tx = _mrx - _dragOffset.left;
-						var newX = ngDraggable.inputEvent(evt).clientX - tx;
-						var newY = ngDraggable.inputEvent(evt).clientY - ty;
-						moveElement(newX, newY);
+                        //Note: does not take into account _centerAnchor
+                        //Click offset in element coordinates
+                        var ty = _mry - _dragOffset.top;
+                        var tx = _mrx - _dragOffset.left;
+                        var newX = ngDraggable.inputEvent(evt).clientX - tx;
+                        var newY = ngDraggable.inputEvent(evt).clientY - ty;
+                        moveElement(newX, newY);
                     }
 
                     $rootScope.$broadcast('draggable:move', { x: _mx, y: _my, tx: _tx, ty: _ty, event: evt, element: element, data: _data, uid: _myid, dragOffset: _dragOffset });


### PR DESCRIPTION
This makes it work correctly when dragging between multiple scrollable areas without needing a clone. It also works properly when scrolling while dragging.